### PR TITLE
feature: 게시글 작성/수정 내용에 이메일 정보 입력기능 추가

### DIFF
--- a/src/main/java/com/example/demo/board/BoardController.java
+++ b/src/main/java/com/example/demo/board/BoardController.java
@@ -87,7 +87,11 @@ public class BoardController {
 	@GetMapping("/posts/{id}/edit")
 	public String editForm(@PathVariable UUID id, Model model) {
 		Post post = postService.findById(id);
-		model.addAttribute("postForm", new PostForm(post.getTitle(), post.getAuthor(), post.getContent()));
+		String email = null;
+		if (post.getOperatorUser() != null) {
+			email = post.getOperatorUser().getEmail();
+		}
+		model.addAttribute("postForm", new PostForm(post.getTitle(), post.getAuthor(), email, post.getContent()));
 		model.addAttribute("mode", "edit");
 		model.addAttribute("postId", id);
 		return "posts/form";

--- a/src/main/java/com/example/demo/board/PostForm.java
+++ b/src/main/java/com/example/demo/board/PostForm.java
@@ -1,6 +1,7 @@
 package com.example.demo.board;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Size;
 
 public class PostForm {
@@ -13,15 +14,21 @@ public class PostForm {
 	@Size(max = 50, message = "작성자 이름은 최대 50자까지 가능합니다.")
 	private String author;
 
+	@NotBlank(message = "이메일을 입력해주세요.")
+	@Email(message = "이메일 형식이 올바르지 않습니다.")
+	@Size(max = 255, message = "이메일은 최대 255자까지 가능합니다.")
+	private String email;
+
 	@NotBlank(message = "내용을 입력해주세요.")
 	private String content;
 
 	public PostForm() {
 	}
 
-	public PostForm(String title, String author, String content) {
+	public PostForm(String title, String author, String email, String content) {
 		this.title = title;
 		this.author = author;
+		this.email = email;
 		this.content = content;
 	}
 
@@ -39,6 +46,14 @@ public class PostForm {
 
 	public void setAuthor(String author) {
 		this.author = author;
+	}
+
+	public String getEmail() {
+		return email;
+	}
+
+	public void setEmail(String email) {
+		this.email = email;
 	}
 
 	public String getContent() {

--- a/src/main/java/com/example/demo/board/mapper/OperatorUserMapper.java
+++ b/src/main/java/com/example/demo/board/mapper/OperatorUserMapper.java
@@ -1,6 +1,7 @@
 package com.example.demo.board.mapper;
 
 import com.example.demo.board.OperatorUser;
+import java.util.UUID;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
@@ -9,4 +10,6 @@ public interface OperatorUserMapper {
 	OperatorUser selectByUsername(@Param("username") String username);
 
 	OperatorUser insert(OperatorUser operatorUser);
+
+	int updateEmail(@Param("id") UUID id, @Param("email") String email);
 }

--- a/src/main/resources/mappers/board/OperatorUserMapper.xml
+++ b/src/main/resources/mappers/board/OperatorUserMapper.xml
@@ -41,4 +41,12 @@
 		)
 		RETURNING id, username, email, password_hash, created_at, updated_at
 	</select>
+
+	<update id="updateEmail">
+		UPDATE operator_user
+		SET
+			email = #{email},
+			updated_at = now()
+		WHERE id = #{id}
+	</update>
 </mapper>

--- a/src/main/resources/static/css/app.css
+++ b/src/main/resources/static/css/app.css
@@ -177,6 +177,7 @@ label span {
 }
 
 input[type="text"],
+input[type="email"],
 textarea {
 	width: 100%;
 	padding: 10px 12px;

--- a/src/main/resources/templates/posts/form.html
+++ b/src/main/resources/templates/posts/form.html
@@ -34,6 +34,12 @@
 			</label>
 
 			<label>
+				<span>이메일</span>
+				<input type="email" th:field="*{email}" placeholder="email@example.com">
+				<small class="error" th:if="${#fields.hasErrors('email')}" th:errors="*{email}">이메일 오류</small>
+			</label>
+
+			<label>
 				<span>내용</span>
 				<textarea rows="10" th:field="*{content}" placeholder="내용을 입력하세요"></textarea>
 				<small class="error" th:if="${#fields.hasErrors('content')}" th:errors="*{content}">내용 오류</small>

--- a/src/test/java/com/example/demo/board/BoardControllerTest.java
+++ b/src/test/java/com/example/demo/board/BoardControllerTest.java
@@ -74,6 +74,7 @@ class BoardControllerTest {
 		mockMvc.perform(post("/posts")
 				.param("title", "제목")
 				.param("author", "작성자")
+				.param("email", "author@example.local")
 				.param("content", "내용")
 				.with(csrf()))
 			.andExpect(status().is3xxRedirection())
@@ -83,6 +84,7 @@ class BoardControllerTest {
 		then(postService).should().create(argThat(form ->
 			"제목".equals(form.getTitle()) &&
 				"작성자".equals(form.getAuthor()) &&
+				"author@example.local".equals(form.getEmail()) &&
 				"내용".equals(form.getContent())));
 	}
 
@@ -91,7 +93,7 @@ class BoardControllerTest {
 		mockMvc.perform(post("/posts").with(csrf()))
 			.andExpect(status().isOk())
 			.andExpect(view().name("posts/form"))
-			.andExpect(model().attributeHasFieldErrors("postForm", "title", "author", "content"));
+			.andExpect(model().attributeHasFieldErrors("postForm", "title", "author", "email", "content"));
 	}
 
 	@Test

--- a/src/test/java/com/example/demo/board/PostServiceTest.java
+++ b/src/test/java/com/example/demo/board/PostServiceTest.java
@@ -49,7 +49,7 @@ class PostServiceTest {
 		setTimestamps(persisted);
 		given(postMapper.insert(any(Post.class))).willReturn(persisted);
 
-	Post saved = postService.create(new PostForm("첫 게시글", "홍길동", "내용입니다"));
+	Post saved = postService.create(new PostForm("첫 게시글", "홍길동", "hong@example.local", "내용입니다"));
 
 	assertThat(saved.getId()).isEqualTo(id);
 	assertThat(saved.getAuthor()).isEqualTo("홍길동");
@@ -82,7 +82,7 @@ class PostServiceTest {
 		setTimestamps(updated);
 		given(postMapper.update(any(Post.class))).willReturn(updated);
 
-		Post result = postService.update(id, new PostForm("새 제목", "다른 작성자", "새 내용"));
+		Post result = postService.update(id, new PostForm("새 제목", "다른 작성자", "other@example.local", "새 내용"));
 
 		assertThat(result.getTitle()).isEqualTo("새 제목");
 		assertThat(result.getAuthor()).isEqualTo("다른 작성자");


### PR DESCRIPTION
  # 개요
  - 게시글 작성/수정 시 작성자 이메일을 입력받아 저장하도록 UI/서비스/매퍼를 확장했습니다.
  - 관련 이슈: N/A

  # 주요 변경
  - 게시글 폼에 이메일 입력란 추가 및 유효성 검증 적용
  - 작성자 이메일을 저장/갱신하도록 서비스 및 MyBatis 매퍼 업데이트
  - 테스트/검증용 케이스 및 폼 스타일 일관성 보완

  # 테스트
  - [x] 단위/통합 테스트: `./gradlew test`
  - [x] 수동 테스트: 게시글 작성/수정 화면에서 이메일 입력 및 저장 확인
  - [ ] 기타:

  # 체크리스트
  - [x] PR 브랜치 대상 확인
  - [ ] 문서/설정 업데이트가 필요한 경우 반영 또는 링크
  - [x] 호환성/데이터 마이그레이션 검토 완료

  # 영향도 및 롤백
  - 영향받는 모듈/서비스: 게시판(Post) 폼, PostService, OperatorUserMapper
  - 롤백 방법: 해당 커밋 revert 또는 이전 배포 JAR로 재배포